### PR TITLE
Honoring input scale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Created by https://www.gitignore.io/api/vim,git,c++,linux
+# Edit at https://www.gitignore.io/?templates=vim,git,c++,linux
+
+### C++ ###
 # Prerequisites
 *.d
 
@@ -23,8 +27,63 @@
 # Compiled Static libraries
 *.lai
 *.la
+*.a
+*.lib
 
 # Executables
 *.exe
 *.out
 *.app
+
+### Git ###
+# Created by git for backups. To disable backups in Git:
+# $ git config --global mergetool.keepBackup false
+*.orig
+
+# Created by git when using merge tools for conflicts
+*.BACKUP.*
+*.BASE.*
+*.LOCAL.*
+*.REMOTE.*
+*_BACKUP_*.txt
+*_BASE_*.txt
+*_LOCAL_*.txt
+*_REMOTE_*.txt
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+# End of https://www.gitignore.io/api/vim,git,c++,linux
+
+Dependencies
+acd2d_gui

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@
     -s                  save decomposition when OpenGL GUI is disabled
     -ps                 save decomposition to postscript (PS) file (when GUI is disabled)
 
+see [POLY\_FORMAT.txt](test_env/POLY_FORMAT.txt) for description of .poly file specifications.
+
 ### GUI options (press key):
 
     d:                  decompose once

--- a/src/acd2d_core.cpp
+++ b/src/acd2d_core.cpp
@@ -113,6 +113,9 @@ namespace acd2d
 		//cut into two polys
 		pair<cd_polygon,cd_polygon> sub_polys;
 		cd_diagonal dia=cutPolys(sub_polys,polys.front(),cut_l);
+
+		sub_polys.first.cur_scale = polys.cur_scale;
+		sub_polys.second.cur_scale = polys.cur_scale;
 	
 		//add into to do
 		todo_list.push_back(sub_polys.first);

--- a/src/acd2d_data.cpp
+++ b/src/acd2d_data.cpp
@@ -562,7 +562,14 @@ namespace acd2d
 	void cd_polygon::normalize()
 	{
 		float r=front().getRadius();
+		cur_scale /= r;
 		scale(1.0/r);
+	}
+
+	void cd_polygon::unnormalize()
+	{
+		scale(1.0 / cur_scale);
+		cur_scale = 1.0;
 	}
 	
 	bool cd_polygon::valid() const //check if this is a valid polygon
@@ -585,6 +592,8 @@ namespace acd2d
 			p.copy(*i);
 			push_back(p);
 		}
+
+		cur_scale = other.cur_scale;
 	}
 	
 	void cd_polygon::destroy()

--- a/src/acd2d_data.h
+++ b/src/acd2d_data.h
@@ -226,6 +226,7 @@ namespace acd2d
 		cd_poly& outmost();
 		void scale(float factor);
 		void normalize();
+        void unnormalize();
 		bool valid() const; //check if this is a valid polygon
 		void copy(const cd_polygon& other);
 		void destroy();
@@ -260,6 +261,11 @@ namespace acd2d
 		typedef list<Dep_El*> DEL;
 		typedef DEL::iterator DIT; 
 		DEL m_DependList; //this decides the order of dependency
+
+        // Store global scale information for post-decomposition recovery
+
+    public:
+        float cur_scale=1.0;
 	};
 	
 	///////////////////////////////////////////////////////////////////////////////

--- a/src/acd2d_util.h
+++ b/src/acd2d_util.h
@@ -96,8 +96,16 @@ namespace acd2d
 	inline void save_polys(ostream& fout, const list<cd_polygon>& polys)
 	{
 		typedef list<cd_polygon>::const_iterator PIT;
-		for( PIT ip=polys.begin();ip!=polys.end();ip++ ) //for each poly
-			fout<<*ip;
+		for( PIT ip=polys.begin();ip!=polys.end();ip++ ){ //for each poly
+			// save normalized version
+			// fout<<*ip;
+
+			// save decomposition at original scale
+			cd_polygon p;
+			p.copy(*ip);
+			p.unnormalize();
+			fout << p;
+		}
 	}
 	
 	inline void save_polys(const string& name, const cd_2d& cd)
@@ -170,7 +178,7 @@ namespace acd2d
 		box[1]=box[3]=-FLT_MAX;
 		
 		for( POIT i=polys.begin();i!=polys.end();i++ ){
-			for(PIT j=i->begin();j!=i->end();j++){    
+			for(PIT j=i->begin();j!=i->end();j++){	
 				double B[4];
 				polyBox(*j,B);
 				


### PR DESCRIPTION
Currently, the application implicitly overrides the input scale by the polygon radius, and the output .poly file scale is different from the input.
Since this is confusing for use-cases where the polygon's scale matters, I figured it might be useful to track the normalization scale factor and apply it back when saving the decomposed version to a file.